### PR TITLE
Add fixes for PHP 7.3

### DIFF
--- a/library/Zend/Cache/Backend.php
+++ b/library/Zend/Cache/Backend.php
@@ -76,7 +76,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach ($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }

--- a/library/Zend/Db/Table/Abstract.php
+++ b/library/Zend/Db/Table/Abstract.php
@@ -1304,13 +1304,13 @@ abstract class Zend_Db_Table_Abstract
         $whereList = array();
         $numberTerms = 0;
         foreach ($args as $keyPosition => $keyValues) {
-            $keyValuesCount = count($keyValues);
             // Coerce the values to an array.
             // Don't simply typecast to array, because the values
             // might be Zend_Db_Expr objects.
             if (!is_array($keyValues)) {
                 $keyValues = array($keyValues);
             }
+            $keyValuesCount = count($keyValues);
             if ($numberTerms == 0) {
                 $numberTerms = $keyValuesCount;
             } else if ($keyValuesCount != $numberTerms) {


### PR DESCRIPTION
1. Replaced a while/each loop with a foreach loop; couldn't see a reason why the code would need to use the deprecated `each()` function as it was neither modifying the array in the loop body, nor starting the loop anywhere but the first element
1. Fix bug where `count()` was being called on a variable prior to that variable being coerced to an array

_I'm going to merge this one for inclusion in another PR, but do please review because this code will be used by both IREx and StarBRITE._