### PR TITLE
Skip setting session options during unit tests

### DIFF
--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -438,7 +438,7 @@ class Zend_Session extends Zend_Session_Abstract
         }
 
         // make sure our default options (at the least) have been set
-        if (!self::$_defaultOptionsSet) {
+        if (!self::$_unitTestEnabled && !self::$_defaultOptionsSet) {
             self::setOptions(is_array($options) ? $options : array());
         }
 


### PR DESCRIPTION
This fix is only for PHPUnit tests. 

_"Session handling has been cleaned up considerably in PHP 7.2.
They treat it as an error to change session settings at a point in the lifecycle where it won't meaningfully affect the response anymore. "_

PHPUnit prints out very early in the process to the buffer, any subsequent attempts alter the headers will cause a 500 error. To solve it we have decided to update our forked Zend version to also check if we are under an automated test via the `$_unitTestEnabled` value and skip setting up the default options since they are not needed for the tests.

Some of the other options that we had and we voted to abandon:

1. send the  PHPUnit output to stderr, which still wasn't solving fully the problem. 
2. use PHPUnit provided annotations to @runInSeparateProcess & @preserveGlobalState disabled. This one solves the issue but slows down the tests.
